### PR TITLE
Convert dependency_mode from "STRICT" to "PRUNE"

### DIFF
--- a/third_party/preact-with-htm/BUILD
+++ b/third_party/preact-with-htm/BUILD
@@ -31,7 +31,7 @@ closure_js_library(
 closure_js_binary(
     name = "app",
     compilation_level = "ADVANCED",
-    dependency_mode = "STRICT",
+    dependency_mode = "PRUNE",
     entry_points = ["third_party/preact-with-htm/index"],
     deps = [":app_js"],
 )

--- a/third_party/preact-without-babel/BUILD
+++ b/third_party/preact-without-babel/BUILD
@@ -28,7 +28,7 @@ closure_js_library(
 closure_js_binary(
     name = "app",
     compilation_level = "ADVANCED",
-    dependency_mode = "STRICT",
+    dependency_mode = "PRUNE",
     entry_points = ["third_party/preact-without-babel/index"],
     deps = [":app_js"],
 )


### PR DESCRIPTION
dependency_mode = "STRICT" is deprecated and will be removed soon; updating to
use its equivalent "PRUNE".