### PR TITLE
Interfaces can only extend interfaces

### DIFF
--- a/third_party/preact/v10_4_6/externs/externs.js
+++ b/third_party/preact/v10_4_6/externs/externs.js
@@ -229,7 +229,7 @@ preact.FunctionComponent.prototype.defaultProps;
  * @extends preact.FunctionComponent<P>
  * @template P
  */
-preact.FunctionalComponent = class { };
+preact.FunctionalComponent;
 
 // interface FunctionalComponent<P = {}> extends FunctionComponent<P> { }
 


### PR DESCRIPTION
Remove `class {}` assignment to interface to fix warning from Closure Compiler.
This is only visible when running Closure Compiler directly; does not appear
when running via Bazel + `rules_closure`.