### PR TITLE
Update Preact link due to git.io deprecation

### DIFF
--- a/third_party/preact-without-babel/README.md
+++ b/third_party/preact-without-babel/README.md
@@ -34,4 +34,4 @@ and verify that it works just the same as the uncompiled version above.
 
 > :horse: Supporting older browsers?  Check out [Preact in ES3](https://github.com/developit/preact-in-es3)
 
-[Preact]: https://git.io/preact
+[Preact]: https://github.com/preactjs/preact


### PR DESCRIPTION
Update https://git.io/preact to point to https://github.com/preactjs/preact,
since git.io is disappearing in a few days:
https://github.blog/changelog/2022-04-25-git-io-deprecation/

We're not changing any code, so we can safely [skip ci].