### PR TITLE
Update Preact.js to Preact; it's cleaner

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,8 @@
-# Using Preact.js
+# Using Preact
 
 [![Build Status][github-ci-badge]][github-ci-url]
 
-[github-ci-badge]: https://github.com/mbrukman/using-preactjs/actions/workflows/main.yml/badge.svg
-[github-ci-url]: https://github.com/mbrukman/using-preactjs/actions/workflows/main.yml
-
-How to build applications using Preact.
+How to build applications using [Preact][preact].
 
 Work-in-progress:
 
@@ -29,5 +26,8 @@ This project is not an official Google project. It is not supported by Google
 and Google specifically disclaims all warranties as to its quality,
 merchantability, or fitness for a particular purpose.
 
+[github-ci-badge]: https://github.com/mbrukman/using-preactjs/actions/workflows/main.yml/badge.svg
+[github-ci-url]: https://github.com/mbrukman/using-preactjs/actions/workflows/main.yml
+[preact]: https://preactjs.com/
 [rules-nodejs-type-errors]: https://github.com/preactjs/preact/issues/758#issuecomment-683881172
 [closure-compiler-typedef-templates]: https://github.com/google/closure-compiler/issues/890


### PR DESCRIPTION
A few additional changes for clarity and cleanups:

* add link to Preact homepage for those folks who are not aware of it
* move all Markdown named links to the bottom of the page

Since we're not modifying any code, we can [skip ci].