### PR TITLE
Update to Ubuntu 24.04 & 22.04 and macOS 13 & 12

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,23 +23,27 @@ on:
 jobs:
   build:
     strategy:
+      fail-fast: false
       matrix:
-        os: [ 'ubuntu-20.04', 'macos-10.15' ]
+        bazel: [ '6.0.0' ]
+        os: [ 'ubuntu-24.04', 'ubuntu-22.04', 'macos-13', 'macos-12' ]
+    env:
+      USE_BAZEL_VERSION: '${{ matrix.bazel }}'
 
     name: Running on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
-      - name: Install Bazelisk
-        uses: bazelbuild/setup-bazelisk@v1
-
-      - name: Setup cache for Bazel
-        uses: actions/cache@v2
+      - uses: bazel-contrib/setup-bazel@0.8.1
         with:
-          path: "~/.cache/bazel"
-          key: bazel
+          # Avoid downloading Bazel every time.
+          bazelisk-cache: true
+          # Store build cache per workflow.
+          disk-cache: ${{ github.workflow }}
+          # Share repository cache between workflows.
+          repository-cache: true
 
       - name: Build
         run: bazel build --config=ci //...

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -14,6 +14,8 @@
 
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
+# We cannot upgrade rules_closure from 0.10 to 0.11 or later versions;
+# see README.md with links for more details as to why.
 http_archive(
     name = "io_bazel_rules_closure",
     sha256 = "7d206c2383811f378a5ef03f4aacbcf5f47fd8650f6abbc3fa89f3a27dd8b176",
@@ -25,5 +27,23 @@ http_archive(
 )
 
 load("@io_bazel_rules_closure//closure:repositories.bzl", "rules_closure_dependencies", "rules_closure_toolchains")
-rules_closure_dependencies()
+
+# rules_closure 0.10.0 references zlib as follows:
+# https://github.com/bazelbuild/rules_closure/blob/9ab7cb8f968ede02cbb708847a6effabcd88b1e4/closure/repositories.bzl#L1025-L1032
+# which points to https://zlib.net/zlib-1.2.11.tar.gz directly, but zlib moves
+# older released versions to https://zlib.net/fossils/... and leaves only recent
+# versions at the top level, which breaks historical references, so we omit it
+# here, and manually add another definition of the zlib rules below.
+rules_closure_dependencies(omit_zlib=True)
 rules_closure_toolchains()
+
+http_archive(
+    name = "zlib",
+    build_file = "@com_google_protobuf//:third_party/zlib.BUILD",
+    sha256 = "c3e5e9fdd5004dcb542feda5ee4f0ff0744628baf8ed2dd5d66f8ca1197cb1a1",
+    strip_prefix = "zlib-1.2.11",
+    urls = [
+        "https://mirror.bazel.build/zlib.net/zlib-1.2.11.tar.gz",
+        "https://zlib.net/fossils/zlib-1.2.11.tar.gz",
+    ],
+)


### PR DESCRIPTION
Additional changes:

* update to actions/checkout@v4
* set `fail-fast: false` so we can see all the failures at once
* replace bazelbuild/setup-bazelisk with bazel-contrib/setup-bazel
* remove actions/cache since it's included in bazel-contrib/setup-bazel
* specify Bazel 6.0 which is the last version before bzlmod
* we can't update Bazel rules_closure from 0.10 to 0.11 or later due to
  typechecking issues with JsCompiler (see README.md for details), but due to
  zlib moving locations and not being found at the location hardcoded in
  rules_closure 0.10, we have to override the zlib library definition and
  provide alternate URLs that are valid for long-term